### PR TITLE
fix social link logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,8 +112,8 @@
         <p id="text-footer">© Created for Samantha Tamiosso. All rights reserved.</p>
     </div>
     <div class="footer-media">
-        <a class="media-link" href="https://www.linkedin.com/in/samantha-colognese-tamiosso/" target="_blank"><i class="fa-brands fa-github"></i></a>
-        <a class="media-link" href="https://github.com/smiosso" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
+        <a class="media-link" href="https://www.linkedin.com/in/samantha-colognese-tamiosso/" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
+        <a class="media-link" href="https://github.com/smiosso" target="_blank"><i class="fa-brands fa-github"></i></a>
     </div>
 </footer>
 </html>


### PR DESCRIPTION
The links referring social media profiles have their corresponding logo switched. Kindly refer to this humble pull request.